### PR TITLE
remove version lock on aws-sdk

### DIFF
--- a/petit.gemspec
+++ b/petit.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aws-sdk', '~> 2'
+  spec.add_dependency 'aws-sdk', '> 2'
   spec.add_dependency 'activesupport'
   spec.add_dependency 'sinatra'
   spec.add_dependency 'jsonapi-serializers'


### PR DESCRIPTION
Relax the major-version constraint on `aws-sdk`, allowing this library to be used with AWS SDK version 3 and up, under the assumption that future major-releases of AWS SDK will be backwards-compatible.

According to the [Upgrading Guide](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/index.html#Upgrading_Guide),

> Aside from gem packaging differences, version 3 interfaces are backwards compatible with version 2.